### PR TITLE
Fix macOS version on available attributes

### DIFF
--- a/sushibar/AppDelegate.swift
+++ b/sushibar/AppDelegate.swift
@@ -15,7 +15,7 @@ fileprivate extension NSTouchBarItemIdentifier {
     static let lane = NSTouchBarItemIdentifier("jp.mzp.touchbar.lane")
 }
 
-@available(OSX 10.12.1, *)
+@available(OSX 10.12.2, *)
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, NSTouchBarProvider, NSTouchBarDelegate {
 


### PR DESCRIPTION
Hi, I've tried to build this sample application.
But I got build error.

In Xcode, `NSTouchBar` is marked available on macOS 10.12.2 or higher.
 
Otherwise, it causes build error with Xcode 8.2:

```log
/Users/cosmo/GitHub/sushibar/sushibar/AppDelegate.swift:23:19: error:
'NSTouchBar' is only available on OS X 10.12.2 or newer
    var touchBar: NSTouchBar?
                      ^
```